### PR TITLE
Replace string dateformat functions with momentjs dateformat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ integration-test/**/*.js
 node_modules
 npm-debug.log
 src/**/*.js
+.idea
+*.iml

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,6 +39,9 @@ module.exports = function(config) {
       'node_modules/zone.js/dist/async-test.js',
       'node_modules/zone.js/dist/fake-async-test.js',
 
+      // MomentJs for dates
+      'node_modules/moment/moment.js',
+
       // RxJs
       { pattern: 'node_modules/rxjs/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/rxjs/**/*.js.map', included: false, watched: false },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "ngc": "node_modules/.bin/ngc -p tsconfig-aot.json && rm integration-test/*.metadata.json"
   },
   "dependencies": {
+    "moment": "^2.17.1",
     "rxjs": "5.0.0-beta.12"
   }
 }

--- a/src/datepicker.component.spec.ts
+++ b/src/datepicker.component.spec.ts
@@ -98,21 +98,21 @@ describe('DatepickerComponent', () => {
       const day = new Date(2016, 3, 15);
       comp.dateFormat = 'YYYY-MM-DD';
       comp.setInputText(day);
-      expect(comp.inputText).toEqual('2016/04/15');
+      expect(comp.inputText).toEqual('2016-04-15');
     });
 
     it('sets correct inputText when dateFormat equals "MM-DD-YYYY"', () => {
       const day = new Date(2016, 3, 15);
       comp.dateFormat = 'MM-DD-YYYY';
       comp.setInputText(day);
-      expect(comp.inputText).toEqual('04/15/2016');
+      expect(comp.inputText).toEqual('04-15-2016');
     });
 
     it('sets correct inputText when dateFormat equals "DD-MM-YYYY"', () => {
       const day = new Date(2016, 3, 15);
       comp.dateFormat = 'DD-MM-YYYY';
       comp.setInputText(day);
-      expect(comp.inputText).toEqual('15/04/2016');
+      expect(comp.inputText).toEqual('15-04-2016');
     });
 
     it('sets correct inputText when dateFormat is a custom function', () => {

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -275,7 +275,7 @@ interface ValidationResult {
           <div class="datepicker__calendar__labels">
             <div
               class="datepicker__calendar__label"
-              *ngFor="let day of dayNames"
+              *ngFor="let day of dayNamesOrdered"
             >
               {{ day }}
             </div>
@@ -342,12 +342,13 @@ export class DatepickerComponent implements OnInit, OnChanges {
   // time
   @Input() calendarDays: Array<number>;
   @Input() currentMonth: string;
-  @Input() dayNames: Array<String>;
+  @Input() dayNames: Array<String> = ['S', 'M', 'T', 'W', 'T', 'F', 'S']; // Default order: firstDayOfTheWeek = 0
   @Input() firstDayOfTheWeek = 0; // 0 For Sunday
   @Input() hoveredDay: Date;
   @Input() months: Array<string>;
   // The label of the cancel button.
   @Input() cancelButtonLabel: string = 'Cancel';
+  dayNamesOrdered: Array<String>;
   calendar: Calendar;
   currentMonthNumber: number;
   currentYear: number;
@@ -405,7 +406,7 @@ export class DatepickerComponent implements OnInit, OnChanges {
     if ((changes['date'] || changes['dateFormat'])) {
       this.syncVisualsWithDate();
     }
-    if (changes['firstDayOfTheWeek']) {
+    if (changes['firstDayOfTheWeek'] || changes['dayNames']) {
       this.updateDayNames();
     }
   }
@@ -448,13 +449,13 @@ export class DatepickerComponent implements OnInit, OnChanges {
    * first day will be sunday.
    */
   private updateDayNames() {
-    this.dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S']; // Default order: firstDayOfTheWeek = 0
-    if (this.firstDayOfTheWeek < 0 || this.firstDayOfTheWeek >= this.dayNames.length) {
+    this.dayNamesOrdered = this.dayNames.slice(); // Copy DayNames with default value (firstDayOfTheWeek = 0)
+    if (this.firstDayOfTheWeek < 0 || this.firstDayOfTheWeek >= this.dayNamesOrdered.length) {
       // Out of range
-      throw Error(`The firstDayOfTheWeek is not in range between ${0} and ${this.dayNames.length - 1}`)
+      throw Error(`The firstDayOfTheWeek is not in range between ${0} and ${this.dayNamesOrdered.length - 1}`)
     } else {
-      this.dayNames = this.dayNames.slice(this.firstDayOfTheWeek, this.dayNames.length)
-        .concat(this.dayNames.slice(0, this.firstDayOfTheWeek)); // Append beginning to end
+      this.dayNamesOrdered = this.dayNamesOrdered.slice(this.firstDayOfTheWeek, this.dayNamesOrdered.length)
+        .concat(this.dayNamesOrdered.slice(0, this.firstDayOfTheWeek)); // Append beginning to end
     }
   }
 

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -5,6 +5,7 @@ import {
 import { FormControl, Validators } from '@angular/forms';
 
 import { Calendar } from './calendar';
+import * as moment from 'moment';
 
 interface DateFormatFunction {
   (date: Date): string;
@@ -312,6 +313,8 @@ interface ValidationResult {
     `
 })
 export class DatepickerComponent implements OnInit, OnChanges {
+  private readonly DEFAULT_FORMAT = 'YYYY-MM-DD';
+
   private dateVal: Date;
   // two way bindings
   @Output() dateChange = new EventEmitter<Date>();
@@ -356,7 +359,7 @@ export class DatepickerComponent implements OnInit, OnChanges {
 
 
   constructor(private renderer: Renderer, private elementRef: ElementRef) {
-    this.dateFormat = 'YYYY-MM-DD';
+    this.dateFormat = this.DEFAULT_FORMAT;
     // view logic
     this.showCalendar = false;
     // colors
@@ -466,37 +469,15 @@ export class DatepickerComponent implements OnInit, OnChanges {
   * Sets the visible input text
   */
   setInputText(date: Date): void {
-    let month: string = (date.getMonth() + 1).toString();
-    // always prefixes one digit numbers with a 0
-    if (month.length < 2) {
-      month = `0${month}`;
-    }
-    let day: string = (date.getDate()).toString();
-    if (day.length < 2) {
-      day = `0${day}`;
-    }
-    // transforms input text into appropiate date format
-    let inputText: string = '';
+    let inputText = "";
     const dateFormat: string | DateFormatFunction = this.dateFormat;
-    if (typeof dateFormat === 'string') {
-      switch (dateFormat.toUpperCase()) {
-        case 'YYYY-MM-DD':
-          inputText = `${date.getFullYear()}/${month}/${day}`;
-          break;
-        case 'MM-DD-YYYY':
-          inputText = `${month}/${day}/${date.getFullYear()}`;
-          break;
-        case 'DD-MM-YYYY':
-          inputText = `${day}/${month}/${date.getFullYear()}`;
-          break;
-        default:
-          inputText = `${date.getFullYear()}/${month}/${day}`;
-          break;
-      }
+    if (dateFormat === undefined || dateFormat === null) {
+      inputText = moment(date).format(this.DEFAULT_FORMAT);
+    } else if (typeof dateFormat === 'string') {
+      inputText = moment(date).format(dateFormat);
     } else if (typeof dateFormat === 'function') {
       inputText = dateFormat(date);
     }
-
     this.inputText = inputText;
   }
 

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -343,6 +343,7 @@ export class DatepickerComponent implements OnInit, OnChanges {
   @Input() calendarDays: Array<number>;
   @Input() currentMonth: string;
   @Input() dayNames: Array<String>;
+  @Input() firstDayOfTheWeek = 0; // 0 For Sunday
   @Input() hoveredDay: Date;
   @Input() months: Array<string>;
   // The label of the cancel button.
@@ -374,8 +375,17 @@ export class DatepickerComponent implements OnInit, OnChanges {
     this.accentColor = this.colors['blue'];
     this.altInputStyle = false;
     // time
-    this.calendar = new Calendar();
-    this.dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+    this.calendar = new Calendar(this.firstDayOfTheWeek);
+    // Calculate day names order
+    this.dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S']; // Default order: firstDayOfTheWeek = 0
+    if (this.firstDayOfTheWeek < 0 || this.firstDayOfTheWeek >= this.dayNames.length) {
+      // Out of range
+      throw Error(`The firstDayOfTheWeek is not in range between ${0} and ${this.dayNames.length - 1}`)
+    } else {
+      this.dayNames = this.dayNames.slice(this.firstDayOfTheWeek, this.dayNames.length)
+                        .concat(this.dayNames.slice(0, this.firstDayOfTheWeek)) // Append beginning to end
+    }
+
     this.months = [
       'January', 'February', 'March', 'April', 'May', 'June', 'July',
       'August', 'September', 'October', 'November', ' December'

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -305,7 +305,7 @@ interface ValidationResult {
             class="datepicker__calendar__cancel"
             (click)="onCancel()"
           >
-            Cancel
+            {{ cancelButtonLabel }}
           </div>
         </div>
       </div>
@@ -345,6 +345,8 @@ export class DatepickerComponent implements OnInit, OnChanges {
   @Input() dayNames: Array<String>;
   @Input() hoveredDay: Date;
   @Input() months: Array<string>;
+  // The label of the cancel button.
+  @Input() cancelButtonLabel: string = 'Cancel';
   calendar: Calendar;
   currentMonthNumber: number;
   currentYear: number;

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -344,10 +344,10 @@ export class DatepickerComponent implements OnInit, OnChanges {
   @Input() currentMonth: string;
   @Input() dayNames: Array<String>;
   @Input() hoveredDay: Date;
+  @Input() months: Array<string>;
   calendar: Calendar;
   currentMonthNumber: number;
   currentYear: number;
-  months: Array<string>;
   // animation
   animate: string;
   // colors

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -376,15 +376,7 @@ export class DatepickerComponent implements OnInit, OnChanges {
     this.altInputStyle = false;
     // time
     this.calendar = new Calendar(this.firstDayOfTheWeek);
-    // Calculate day names order
-    this.dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S']; // Default order: firstDayOfTheWeek = 0
-    if (this.firstDayOfTheWeek < 0 || this.firstDayOfTheWeek >= this.dayNames.length) {
-      // Out of range
-      throw Error(`The firstDayOfTheWeek is not in range between ${0} and ${this.dayNames.length - 1}`)
-    } else {
-      this.dayNames = this.dayNames.slice(this.firstDayOfTheWeek, this.dayNames.length)
-                        .concat(this.dayNames.slice(0, this.firstDayOfTheWeek)) // Append beginning to end
-    }
+    this.updateDayNames();
 
     this.months = [
       'January', 'February', 'March', 'April', 'May', 'June', 'July',
@@ -412,6 +404,9 @@ export class DatepickerComponent implements OnInit, OnChanges {
   ngOnChanges(changes: { [propertyName: string]: SimpleChange }) {
     if ((changes['date'] || changes['dateFormat'])) {
       this.syncVisualsWithDate();
+    }
+    if (changes['firstDayOfTheWeek']) {
+      this.updateDayNames();
     }
   }
 
@@ -446,6 +441,21 @@ export class DatepickerComponent implements OnInit, OnChanges {
     const calendarArray = this.calendar.monthDays(this.currentYear, this.currentMonthNumber);
     this.calendarDays = [].concat.apply([], calendarArray);
     this.calendarDays = this.filterInvalidDays(this.calendarDays);
+  }
+
+  /**
+   * Update the day names order. The order can be modified with the firstDayOfTheWeek input, while 0 means that the
+   * first day will be sunday.
+   */
+  private updateDayNames() {
+    this.dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S']; // Default order: firstDayOfTheWeek = 0
+    if (this.firstDayOfTheWeek < 0 || this.firstDayOfTheWeek >= this.dayNames.length) {
+      // Out of range
+      throw Error(`The firstDayOfTheWeek is not in range between ${0} and ${this.dayNames.length - 1}`)
+    } else {
+      this.dayNames = this.dayNames.slice(this.firstDayOfTheWeek, this.dayNames.length)
+        .concat(this.dayNames.slice(0, this.firstDayOfTheWeek)); // Append beginning to end
+    }
   }
 
   /**

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -376,7 +376,6 @@ export class DatepickerComponent implements OnInit, OnChanges {
     this.accentColor = this.colors['blue'];
     this.altInputStyle = false;
     // time
-    this.calendar = new Calendar(this.firstDayOfTheWeek);
     this.updateDayNames();
 
     this.months = [
@@ -454,6 +453,7 @@ export class DatepickerComponent implements OnInit, OnChanges {
       // Out of range
       throw Error(`The firstDayOfTheWeek is not in range between ${0} and ${this.dayNamesOrdered.length - 1}`)
     } else {
+      this.calendar = new Calendar(this.firstDayOfTheWeek);
       this.dayNamesOrdered = this.dayNamesOrdered.slice(this.firstDayOfTheWeek, this.dayNamesOrdered.length)
         .concat(this.dayNamesOrdered.slice(0, this.firstDayOfTheWeek)); // Append beginning to end
     }

--- a/systemjs.config.js
+++ b/systemjs.config.js
@@ -24,6 +24,7 @@
 
       // other libraries
       'rxjs':                      'npm:rxjs',
+      'moment':                      'npm:moment/moment.js',
       'angular-in-memory-web-api': 'npm:angular-in-memory-web-api/bundles/in-memory-web-api.umd.js'
     },
     // packages tells the System loader how to load when no filename and/or no extension


### PR DESCRIPTION
I had problems with the european dateformat "DD.MM.YYYY". In order to solve that issue I replaced the current implementation of the hard coded dateformats with the dateformats of [momentjs](http://momentjs.com/).

I also set the months as an input. This allows user to replace the month labels. This is necessary if you want to tranlate the values to other languages.