### PR TITLE
#57: Cast Calendar to any to fix compile error on strict no implicitl…

### DIFF
--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -62,7 +62,7 @@ export class Calendar {
 
 const months = "JAN FEB MAR APR MAY JUN JUL AUG SEP OCT NOV DEC".split(" ");
 for (var i=0; i<months.length; i++) {
-    Calendar[months[i]] = i;
+    (<any>Calendar)[months[i]] = i;
 }
 
 /*!


### PR DESCRIPTION
Cast Calendar to any to fix compile error when `"noImplicitAny": true` 