### PR TITLE
Critical fix to parse numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ integration-test/**/*.js
 node_modules
 npm-debug.log
 src/**/*.js
+.vscode/

--- a/src/datepicker.component.ts
+++ b/src/datepicker.component.ts
@@ -371,7 +371,7 @@ export class DatepickerComponent implements OnInit, OnChanges {
     this.accentColor = this.colors['blue'];
     this.altInputStyle = false;
     // time
-    this.calendar = new Calendar(this.weekStart);
+    this.calendar = new Calendar();
     this.dayNames = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
     this.months = [
       'January', 'February', 'March', 'April', 'May', 'June', 'July',
@@ -393,8 +393,8 @@ export class DatepickerComponent implements OnInit, OnChanges {
   }
 
   ngOnInit() {
-    this.calendar.firstWeekDay = this.weekStart;
-    for (let i = 0; i < this.weekStart; i++) {
+    this.calendar.firstWeekDay = Number(this.weekStart);
+    for (let i = 0; i < Number(this.weekStart); i++) {
       this.dayNames.push(this.dayNames.shift());
     }
     this.syncVisualsWithDate();


### PR DESCRIPTION
Hello.

Removed useless this.weekStart from line 374, it did nothing. 

On line 396 and 397 I parse the string parameter input to a number, it will crash on newer javascript or angular engines, I'm not sure what has changed, but this will fix it. 

Also added vscode to gitignore. 